### PR TITLE
check_boot_jars: Add coloros package name to allowed list

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -303,6 +303,7 @@ oplus\..*
 vendor\.oplus\..*
 com\.oneplus\..*
 vendor\.oneplus\..*
+com\.color\..*
 
 # QC adds
 com.qualcomm.qti


### PR DESCRIPTION
Needed for OnePlus Camera.